### PR TITLE
Let git manage line endings of text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# When text is set to "auto", the path is marked for automatic end-of-line conversion.
+# If Git decides that the content is text, its line endings are converted to LF on 
+# checkin. When the file has been committed with CRLF, no conversion is done.
+# https://git-scm.com/docs/gitattributes
+* text=auto
+


### PR DESCRIPTION
By setting "* text=auto" in .gitattributes, we are telling git to
decide if the content is text, and if so, convert line endings to
LF on checkin.