### PR TITLE
Copyedits

### DIFF
--- a/NUG/chunking.md
+++ b/NUG/chunking.md
@@ -4,10 +4,10 @@
 
 ## The Chunk Cache {#chunk_cache}
 
-For good performance your chunk cache must be larger than one chunk of your data - preferably that it be large enough to hold multiple chunks of data.
+For good performance your chunk cache must be larger than one chunk of your data - preferably large enough to hold multiple chunks of data.
 
 In addition, when a file is opened (or a variable created in an open file), the netCDF-4 library checks to make sure the default chunk cache size will work for that variable.
-The cache will be large enough to hold N chunks, up to a maximum size of M bytes. (Both N and M are settable at configure time with the `–with-default-chunks-in-cache` and the `–with-max-default-cache-size` options to the configure script.
+The cache will be large enough to hold N chunks, up to a maximum size of M bytes. (Both N and M are settable at configure time with the `–with-default-chunks-in-cache` and the `–with-max-default-cache-size` options added to the configure script.
 Currently they are set to **10** and **64** MB.)
 
 To change the default chunk cache size, use the `set_chunk_cache()` function before opening the file with nc_set_chunk_cache().

--- a/NUG/netcdf_data_set_components.md
+++ b/NUG/netcdf_data_set_components.md
@@ -226,9 +226,9 @@ The external type of an attribute is specified when it is created. The
 types permitted for attributes are the same as the netCDF external
 data types for variables. Attributes with the same name for different
 variables should sometimes be of different types. For example, the
-attribute valid_max specifying the maximum valid data value for a
-variable of type int should be of type int, whereas the attribute
-valid_max for a variable of type double should instead be of type
+attribute valid_max, specifying the maximum valid data value for a
+variable of type int, should be of type int. Whereas the attribute
+valid_max for a variable of type double, should instead be of type
 double.
 
 Attributes are more dynamic than variables or dimensions; they can be
@@ -572,7 +572,7 @@ world-premire of her smash hit "Format me baby, one more time."
 In June, 2008, netCDF-4.0 was released. Version 3.6.3, the same code
 but with netcdf-4 features turned off, was released at the same
 time. The 4.0 release uses HDF5 1.8.1 as the data storage layer for
-netcdf, and introduces many new features including groups and
+netCDF, and introduces many new features including groups and
 user-defined types. The 3.6.3/4.0 releases also introduced handling of
 UTF8-encoded Unicode names.
 
@@ -589,7 +589,7 @@ of the UDUNITS library for handling “units” attributes, and inclusion
 of libcf to assist in creating data compliant with the Climate and
 Forecast (CF) metadata conventions.
 
-In September, 2010, the Netcdf-Java/CDM (Common Data Model) version
+In September, 2010, the NetCDF-Java/CDM (Common Data Model) version
 4.2 library was declared stable and made available to users. This
 100%-Java implementation provided a read-write interface to netCDF-3
 classic format files, as well as a read-only interface to
@@ -672,7 +672,7 @@ vector.
 A mapped array section is similar to a subsampled array section except
 that an additional index mapping vector allows one to specify how data
 values associated with the netCDF variable are arranged in memory. The
-offset of each value from the reference location, is given by the sum
+offset of each value from the reference location is given by the sum
 of the products of each index (of the imaginary internal array which
 would be used if there were no mapping) by the corresponding element
 of the index mapping vector. The number of values accessed is the same
@@ -729,7 +729,7 @@ start index and some edge lengths. The start index should be (0, 1, 0,
 0) in C, because we want to start at the beginning of each of the
 time, lon, and lat dimensions, but we want to begin at the second
 value of the level dimension. The edge lengths should be (3, 1, 5, 10)
-in C, (since we want to get data for all three time values, only one
+in C, since we want to get data for all three time values, only one
 level value, all five lat values, and all 10 lon values. We should
 expect to get a total of 150 floating-point values returned (3 * 1 * 5
 * 10), and should provide enough space in our array for this many. The
@@ -772,10 +772,7 @@ variable elements and their memory addresses.
 With mapped array access, the offset (number of array elements) from
 the origin of a memory-resident array to a particular point is given
 by the inner product[1] of the index mapping vector with the point's
-coordinate offset vector. A point's coordinate offset vector gives,
-for each dimension, the offset from the origin of the containing array
-to the point.In C, a point's coordinate offset vector is the same as
-its coordinate vector.
+coordinate offset vector. A point's coordinate offset vector gives, for each dimension, the offset from the origin of the containing array to the point. In C, a point's coordinate offset vector is the same as its coordinate vector.
 
 The index mapping vector for a regular array section would have–in
 order from most rapidly varying dimension to most slowly–a constant 1,

--- a/NUG/netcdf_data_set_components.md
+++ b/NUG/netcdf_data_set_components.md
@@ -806,7 +806,7 @@ description of the interfaces for mapped array access. See Write a
 Mapped Array of Values - nc_put_varm_ type.
 
 Note that, although the netCDF abstraction allows the use of
-subsampled or mapped array-section access there use is not
+subsampled or mapped array-section access, there use is not
 required. If you do not need these more general forms of access, you
 may ignore these capabilities and use single value access or regular
 array section access instead.

--- a/NUG/netcdf_introduction.md
+++ b/NUG/netcdf_introduction.md
@@ -43,7 +43,7 @@ Starting with this version, the netCDF library can use HDF5 files as its base fo
 (Only HDF5 files created with netCDF-4 can be understood by netCDF-4).
 
 Starting from version 4.4.0, netCDF included the support of CDF-5 format.
-In order to allows defining large array variables with more than 4-billion elements, CDF-5 replaces most of the 32-bit integers used to describe metadata in file header with 64-bit integers.
+In order to allow defining large array variables with more than 4-billion elements, CDF-5 replaces most of the 32-bit integers used to describe metadata in file header with 64-bit integers.
 In addition, it supports the following new external data types: NC_UBYTE, NC_USHORT, NC_UINT, NC_INT64, and NC_UINT64.
 The CDF-5 format specifications can be found at http://cucis.ece.northwestern.edu/projects/PnetCDF/CDF-5.html.
 
@@ -107,7 +107,7 @@ Since CDF-2 format was introduced in version 3.6.0, earlier versions of the netC
 
 ##  NetCDF 64-bit Data Format (CDF-5) {#netcdf_64bit_data_format}
 
-To allow large variables with more than 4-billion array elements, 64-bit data format is develop to support such I/O requests.
+To allow large variables with more than 4-billion array elements, 64-bit data format is developed to support such I/O requests.
 
 Files with the 64-bit data are identified with a "CDF\005" at the beginning of the file.
 In this documentation this format is called CDF-5 format.
@@ -192,7 +192,7 @@ This limitation is a result of 32-bit offsets used for storing relative offsets 
 Since one of the goals of netCDF is portable data, and some file systems still can't deal with files larger than 2 GiB, it is best to keep files that must be portable below this limit.
 Nevertheless, it is possible to create and access netCDF files larger than 2 GiB on platforms that provide support for such files (see \ref large_file_support).
 
-The CDF-2 format allows large files, and makes it easy to create to create fixed variables of about 4 GiB, and record variables of about 4 GiB per record (see \ref netcdf_64bit_offset_format).
+The CDF-2 format allows large files, and makes it easy to create fixed variables of about 4 GiB, and record variables of about 4 GiB per record (see \ref netcdf_64bit_offset_format).
 However, old netCDF applications will not be able to read the 64-bit offset files until they are upgraded to at least version 3.6.0 of netCDF (i.e. the version in which 64-bit offset format was introduced).
 
 With the netCDF-4/HDF5 format, size limitations are further relaxed, and files can be as large as the underlying file system supports.


### PR DESCRIPTION
- In collaboration with I.P.
- Noticed that I.P.'s docs weren't exactly the same as these
   
In "Improving Performance with Chunking",  I did not see this paragraph: 

-      "When data are first read or written to a netCDF-4/HDF5 variable..."

In "An Introduction to netCDF", I did not see this phrase :      

-        "index mapping"

In "NetCDF Utilities", I did not see the following phrases: 
-       "For example, “units” might be an attribute represented by a string such as “celsius”."
-       "However names commencing with underscore are reserved for system use."
-       "Thus, row-order rather than column order is used for matrices."
-       "So using netcdf on Windows may cause some problems with respect to objects like file paths."