### PR TITLE
Correct for a missing percent sign in format document

### DIFF
--- a/NUG/file_format_specifications.md
+++ b/NUG/file_format_specifications.md
@@ -70,7 +70,7 @@ Comments in the grammar point to the notes and special cases, and help to clarif
                                   // special2 chars are recently permitted in
                                   // names (and require escaping in CDL).
                                   // Note: '/' is not permitted.
-     special2     = ' ' | '!' | '"' | '#'  | '$' | '%' | '&' | '\'' |
+     special2     = ' ' | '!' | '"' | '#'  | '$' | '\%' | '&' | '\'' |
                     '(' | ')' | '*' | ','  | ':' | ';' | '<' | '='  |
                     '>' | '?' | '[' | '\\' | ']' | '^' | '`' | '{'  |
                     '|' | '}' | '~'


### PR DESCRIPTION
Fix a missing percent sign in file_format_specifications.md, in support of https://github.com/Unidata/netcdf-c/issues/1609