### PR TITLE
Update path to get GitHub action to pass. 

### DIFF
--- a/.github/workflows/doxygen_build.yml
+++ b/.github/workflows/doxygen_build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: mattnotmitt/doxygen-action@v1
         with:
-          working-directory: 'NUG/'
+          working-directory: 'NUG-doxygen/'
           doxyfile-path: 'Doxyfile'
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
We will need to revamp the Github Actions, but this will at least get it to pass for now.