### PR TITLE
Migrate from docker.unidata.ucar.edu to docker.io for doc build image

### DIFF
--- a/NUG-gradle/build.gradle.kts
+++ b/NUG-gradle/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("base")
 }
 
-val dockerImage = "docker.unidata.ucar.edu/unidata-jekyll-docs:0.0.6"
+val dockerImage = "docker.io/unidata/unidata-jekyll-docs:0.0.6"
 
 val buildDoc = tasks.register<Exec>(name = "buildJekyllSite") {
     group = "documentation"


### PR DESCRIPTION
Use the unidata-jekyll-doc image from dockerhub when building the NUG 2 with gradle.